### PR TITLE
feat: improve ghost piece movement with accurate collision detection

### DIFF
--- a/go-tetris-ws/tetris/game.go
+++ b/go-tetris-ws/tetris/game.go
@@ -8,6 +8,7 @@ import (
 // Game represents the Tetris game state.
 type Game struct {
 	currentTetromino *Tetromino
+	ghostTetromino   *Tetromino // New ghost piece
 	board            [][]bool
 	lastFallTime     time.Time
 	lastMoveTime     time.Time
@@ -41,6 +42,8 @@ func (g *Game) Update() error {
 		}
 		return nil // Prevent input if game is over
 	}
+
+	g.updateGhostPiece() // Ensure ghost is always updated
 
 	currentTime := time.Now()
 
@@ -140,4 +143,24 @@ func (g *Game) ResetGame() {
 	g.lastFallTime = time.Now()
 	g.lastMoveTime = time.Now()
 	g.lastKeyState = make(map[ebiten.Key]bool) // Reset key tracking
+}
+
+// updateGhostPiece calculates where the ghost piece should land
+func (g *Game) updateGhostPiece() {
+	if g.currentTetromino == nil {
+		return
+	}
+
+	// Create a new Tetromino for the ghost piece
+	g.ghostTetromino = &Tetromino{
+		shape:         g.currentTetromino.shape,
+		x:             g.currentTetromino.x,
+		y:             g.currentTetromino.y,
+		rotationState: g.currentTetromino.rotationState,
+	}
+
+	// Move the ghost piece down **until it reaches a collision**
+	for g.canMoveTetromino(g.ghostTetromino, 0, 1) {
+		g.ghostTetromino.y++
+	}
 }

--- a/go-tetris-ws/tetris/tetromino.go
+++ b/go-tetris-ws/tetris/tetromino.go
@@ -114,3 +114,13 @@ func (t *Tetromino) HardDrop(board [][]bool) {
 	}
 }
 
+// canMoveTetromino checks if a given Tetromino can move without collision.
+func (g *Game) canMoveTetromino(t *Tetromino, dx, dy int) bool {
+	for _, pos := range TetrominoRotations[t.shape][t.rotationState] {
+		x, y := t.x+pos[0]+dx, t.y+pos[1]+dy
+		if x < 0 || x >= BoardWidth || y >= BoardHeight || (y >= 0 && g.board[y][x]) {
+			return false // Collision detected
+		}
+	}
+	return true
+}

--- a/go-tetris-ws/tetris/ui.go
+++ b/go-tetris-ws/tetris/ui.go
@@ -18,10 +18,10 @@ func drawCell(screen *ebiten.Image, x, y int, col color.Color) {
 	screen.DrawImage(cell, op)
 }
 
-// Draw renders the Tetromino correctly after rotation.
-func (t *Tetromino) Draw(screen *ebiten.Image) {
+// Modify Draw function to accept color input
+func (t *Tetromino) Draw(screen *ebiten.Image, col color.RGBA) {
 	for _, pos := range TetrominoRotations[t.shape][t.rotationState] {
-		drawCell(screen, t.x+pos[0], t.y+pos[1], color.RGBA{0, 255, 0, 255}) // Green block
+		drawCell(screen, t.x+pos[0], t.y+pos[1], col)
 	}
 }
 
@@ -36,9 +36,14 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		}
 	}
 
-	// Draw active Tetromino
+	// Draw ghost piece first (semi-transparent)
+	if g.ghostTetromino != nil {
+		g.ghostTetromino.Draw(screen, color.RGBA{100, 100, 100, 100}) // Faded color
+	}
+
+	// Draw actual Tetromino
 	if g.currentTetromino != nil {
-		g.currentTetromino.Draw(screen)
+		g.currentTetromino.Draw(screen, color.RGBA{0, 255, 0, 255})
 	}
 
 	// Display Score


### PR DESCRIPTION
- Properly clone ghost piece instead of modifying current Tetromino
- Ensure ghost piece respects rotation state when falling
- Use `canMoveTetromino()` to prevent floating or incorrect positioning
- Fix issue where ghost piece did not align with rotated Tetromino shape